### PR TITLE
rz_form: add support for redirect after successful form submit

### DIFF
--- a/app/sets/rukzuk/rz_core/modules/rz_form/module/form.json
+++ b/app/sets/rukzuk/rz_core/modules/rz_form/module/form.json
@@ -317,7 +317,7 @@
                     "params": [
                         {
                             "name": "CMSvar",
-                            "value": "confirmationText",
+                            "value": "confirmationType",
                             "allowBlank": false,
                             "minLength": 3,
                             "maskRe": {},
@@ -328,8 +328,14 @@
                         },
                         {
                             "name": "xtype",
-                            "value": "textarea",
+                            "value": "CMStabbedfieldset",
                             "xtype": null
+                        },
+                        {
+                            "name": "isResponsive",
+                            "value": false,
+                            "fieldLabel": "__i18n_formElements.isResponsive",
+                            "xtype": "checkbox"
                         },
                         {
                             "name": "isMeta",
@@ -339,57 +345,228 @@
                         },
                         {
                             "name": "fieldLabel",
-                            "value": "{\"de\":\"Text nach Absenden des Formulars\",\"en\":\"Text after form submit\"}",
+                            "value": "{\"de\":\"Nach dem Absenden\", \"en\": \"After submit\"}",
                             "xtype": "textfield",
                             "allowBlank": true,
                             "emptyText": "__i18n_formElements.fieldLabelOptionalEmptyText",
                             "fieldLabel": "__i18n_formElements.fieldLabel"
                         },
                         {
-                            "name": "labelAlign",
-                            "value": "top",
-                            "xtype": "combo",
-                            "fieldLabel": "__i18n_formTabEditor.labelAlignLabel",
-                            "editable": false,
-                            "lazyRender": true,
-                            "triggerAction": "all",
-                            "store": [
-                                [
-                                    "left",
-                                    "__i18n_formTabEditor.labelAlignLeft"
-                                ],
-                                [
-                                    "top",
-                                    "__i18n_formTabEditor.labelAlignTop"
-                                ],
-                                [
-                                    "right",
-                                    "__i18n_formTabEditor.labelAlignRight"
-                                ],
-                                [
-                                    "hide",
-                                    "__i18n_formTabEditor.labelAlignHide"
-                                ]
-                            ]
-                        },
-                        {
-                            "name": "height",
-                            "value": 200,
-                            "xtype": "numberfield",
-                            "allowBlank": false,
-                            "fieldLabel": "__i18n_formElements.heightLabel"
-                        },
-                        {
                             "name": "value",
-                            "value": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\nUt enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
-                            "xtype": null
+                            "xtype": null,
+                            "value": "text"
                         }
                     ],
                     "descr": {
-                        "text": "__i18n_formElements.elementTextArea",
-                        "iconCls": "textarea",
-                        "hasValue": true
-                    }
+                        "id": "TabbedFieldSet",
+                        "text": "__i18n_formElements.elementTabbedFieldSet",
+                        "iconCls": "tabbedfieldset",
+                        "hasValue": true,
+                        "allowChildNodes": true
+                    },
+                    "items": [
+                        {
+                            "params": [
+                                {
+                                    "name": "xtype",
+                                    "value": "CMStabpage",
+                                    "xtype": null
+                                },
+                                {
+                                    "name": "tabValue",
+                                    "xtype": "textfield",
+                                    "allowBlank": false,
+                                    "emptyText": "__i18n_formElements.groupValueEmptyText",
+                                    "fieldLabel": "__i18n_formElements.groupValueFieldLabel",
+                                    "value": "text"
+                                },
+                                {
+                                    "name": "title",
+                                    "value": "{\"de\": \"Text anzeigen\", \"en\": \"Show Text\"}",
+                                    "xtype": "textfield",
+                                    "allowBlank": false,
+                                    "emptyText": "__i18n_formElements.title",
+                                    "fieldLabel": "__i18n_formElements.title"
+                                },
+                                {
+                                    "name": "value",
+                                    "xtype": null,
+                                    "value": "text"
+                                }
+                            ],
+                            "descr": {
+                                "id": "TabPage",
+                                "text": "__i18n_formElements.elementTabPage",
+                                "iconCls": "tabpage",
+                                "hasValue": false,
+                                "allowChildNodes": true
+                            },
+                            "items": [
+                                {
+                                    "params": [
+                                        {
+                                            "name": "CMSvar",
+                                            "value": "confirmationText",
+                                            "allowBlank": false,
+                                            "minLength": 3,
+                                            "maskRe": {},
+                                            "stripCharsRe": {},
+                                            "xtype": "textfield",
+                                            "emptyText": "__i18n_generatedFormPanel.varNameEmptyText",
+                                            "fieldLabel": "__i18n_generatedFormPanel.varNameLabel"
+                                        },
+                                        {
+                                            "name": "xtype",
+                                            "value": "textarea",
+                                            "xtype": null
+                                        },
+                                        {
+                                            "name": "isMeta",
+                                            "value": false,
+                                            "fieldLabel": "__i18n_formElements.isGlobal",
+                                            "xtype": "checkbox"
+                                        },
+                                        {
+                                            "name": "fieldLabel",
+                                            "value": "{\"de\":\"Text nach Absenden des Formulars\",\"en\":\"Text after form submit\"}",
+                                            "xtype": "textfield",
+                                            "allowBlank": true,
+                                            "emptyText": "__i18n_formElements.fieldLabelOptionalEmptyText",
+                                            "fieldLabel": "__i18n_formElements.fieldLabel"
+                                        },
+                                        {
+                                            "name": "labelAlign",
+                                            "value": "top",
+                                            "xtype": "combo",
+                                            "fieldLabel": "__i18n_formTabEditor.labelAlignLabel",
+                                            "editable": false,
+                                            "lazyRender": true,
+                                            "triggerAction": "all",
+                                            "store": [
+                                                [
+                                                    "left",
+                                                    "__i18n_formTabEditor.labelAlignLeft"
+                                                ],
+                                                [
+                                                    "top",
+                                                    "__i18n_formTabEditor.labelAlignTop"
+                                                ],
+                                                [
+                                                    "right",
+                                                    "__i18n_formTabEditor.labelAlignRight"
+                                                ],
+                                                [
+                                                    "hide",
+                                                    "__i18n_formTabEditor.labelAlignHide"
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "name": "height",
+                                            "value": 200,
+                                            "xtype": "numberfield",
+                                            "allowBlank": false,
+                                            "fieldLabel": "__i18n_formElements.heightLabel"
+                                        },
+                                        {
+                                            "name": "value",
+                                            "value": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\nUt enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                                            "xtype": null
+                                        }
+                                    ],
+                                    "descr": {
+                                        "text": "__i18n_formElements.elementTextArea",
+                                        "iconCls": "textarea",
+                                        "hasValue": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "params": [
+                                {
+                                    "name": "xtype",
+                                    "value": "CMStabpage",
+                                    "xtype": null
+                                },
+                                {
+                                    "name": "tabValue",
+                                    "xtype": "textfield",
+                                    "allowBlank": false,
+                                    "emptyText": "__i18n_formElements.groupValueEmptyText",
+                                    "fieldLabel": "__i18n_formElements.groupValueFieldLabel",
+                                    "value": "redirect"
+                                },
+                                {
+                                    "name": "title",
+                                    "value": "{\"de\":\"Seite anzeigen\", \"en\": \"Redirect to Page\"}",
+                                    "xtype": "textfield",
+                                    "allowBlank": false,
+                                    "emptyText": "__i18n_formElements.title",
+                                    "fieldLabel": "__i18n_formElements.title"
+                                },
+                                {
+                                    "name": "value",
+                                    "xtype": null,
+                                    "value": "redirect"
+                                }
+                            ],
+                            "descr": {
+                                "id": "TabPage",
+                                "text": "__i18n_formElements.elementTabPage",
+                                "iconCls": "tabpage",
+                                "hasValue": false,
+                                "allowChildNodes": true
+                            },
+                            "items": [
+                                {
+                                    "params": [
+                                        {
+                                            "name": "CMSvar",
+                                            "value": "confirmationPageId",
+                                            "allowBlank": false,
+                                            "minLength": 3,
+                                            "maskRe": {},
+                                            "stripCharsRe": {},
+                                            "xtype": "textfield",
+                                            "emptyText": "__i18n_generatedFormPanel.varNameEmptyText",
+                                            "fieldLabel": "__i18n_generatedFormPanel.varNameLabel"
+                                        },
+                                        {
+                                            "name": "xtype",
+                                            "value": "CMSinternallinkchooser",
+                                            "xtype": null
+                                        },
+                                        {
+                                            "name": "isMeta",
+                                            "value": false,
+                                            "fieldLabel": "__i18n_formElements.isGlobal",
+                                            "xtype": "checkbox"
+                                        },
+                                        {
+                                            "name": "fieldLabel",
+                                            "value": "{\"de\": \"Zielseite\", \"en\": \"Redirect target\"}",
+                                            "xtype": "textfield",
+                                            "allowBlank": true,
+                                            "emptyText": "__i18n_formElements.fieldLabelOptionalEmptyText",
+                                            "fieldLabel": "__i18n_formElements.fieldLabel"
+                                        },
+                                        {
+                                            "name": "value",
+                                            "value": null,
+                                            "xtype": null
+                                        }
+                                    ],
+                                    "descr": {
+                                        "id": "InternalLinkChooser",
+                                        "text": "__i18n_formElements.elementInternalLinkChooser",
+                                        "iconCls": "anchor",
+                                        "hasValue": true
+                                    }
+                                }
+                            ]
+                        }
+                    ]
                 }
             ],
             "id": "5c67b404-28ac-43fc-982d-09017e9b572e"
@@ -522,6 +699,8 @@
         "senderMail": "",
         "mailSubject": "New Message via Website",
         "confirmationText": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\nUt enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+        "confirmationType": "text",
+        "confirmationPageId": null,
         "cssEnableLabelAlign": "left"
     }
 }

--- a/app/sets/rukzuk/rz_core/modules/rz_form/module/rz_form.php
+++ b/app/sets/rukzuk/rz_core/modules/rz_form/module/rz_form.php
@@ -50,19 +50,45 @@ class rz_form extends SimpleModule
   private $http = null;
 
   /**
-   * @param RenderAPI  $renderApi
-   * @param Unit       $unit
-   * @param ModuleInfo $moduleInfo
+   * After submit redirect support (actual redirect is done in rz_root)
+   * @param $api
+   * @param $unit
+   * @param $moduleInfo
+   * @return array
    */
-  public function renderContent($renderApi, $unit, $moduleInfo)
+  protected function httpRedirect($api, $unit, $moduleInfo)
   {
+    $isRedirect = ($api->getFormValue($unit, 'confirmationType') == 'redirect');
+    list($form, $honeyPotComponent) = $this->setupForm($unit);
 
-    $formSend = false;
+    if ($isRedirect) {
+      try {
+        $formSend = $this->checkFormAndSendMail($api, $unit, $honeyPotComponent);
+        if ($formSend) {
+          $nav = $api->getNavigation();
+          $internalUrl = $nav->getPage($api->getFormValue($unit, 'confirmationPageId'))->getUrl();
+          return array('url' => $internalUrl);
+        }
+      } catch (\Exception $e) {
+        // do nothing - we don't know what to do if send fails
+        // renderContent will try to send the mail again - if it fails again it will show the error.
+      }
+      return array();
+    }
+  }
+
+  /**
+   * Setup the form objects
+   * @param $unit
+   * @return array
+   */
+  private function setupForm($unit)
+  {
     $this->http = new \Request();
     $form = new \Form();
     $honeyPotComponent = new \HoneyPotComponent();
     $this->formSubmit = new \FormSubmit();
-    $postRequest = $this->formSubmit->getPostValues();
+
     $elementProperties = $form->getElementProperties();
 
     $elementProperties->setId("form" . str_replace("-", "", $unit->getId()));
@@ -71,6 +97,20 @@ class rz_form extends SimpleModule
     $elementProperties->addAttribute('enctype', 'multipart/form-data');
     $form->add($honeyPotComponent->getHoneyPot());
     $form->add($honeyPotComponent->getFormUnitIdentifier($unit->getId()));
+    return array($form, $honeyPotComponent);
+  }
+
+  /**
+   * Check for a valid form and send email
+   * @param $renderApi
+   * @param $unit
+   * @param $honeyPotComponent
+   * @return bool
+   * @throws \Exception
+   */
+  private function checkFormAndSendMail($renderApi, $unit, $honeyPotComponent)
+  {
+    $postRequest = $this->formSubmit->getPostValues();
 
     if ($this->formSubmit->isValid($renderApi, $unit)
       && count($postRequest) > 0
@@ -80,25 +120,48 @@ class rz_form extends SimpleModule
       $this->formSubmit->setFieldLabelsToFormValueSet($renderApi);
       try {
         $this->sentEmail($renderApi, $unit, $postRequest);
-        $formSend = true;
+        return true;
       } catch (\Exception $e) {
-        $errorText = new \Span();
-        $errorText->setContent("Unable to send email:<br />".$e->getMessage());
-        $errorContainer = new \Container();
-        $errorContainer->add($errorText);
-        $errorContainer->getElementProperties()->addClass('vf__main_error');
-        $form->add($errorContainer);
+        throw $e;
       }
+    }
+    return false;
+  }
+
+
+  /**
+   * @param RenderAPI  $renderApi
+   * @param Unit       $unit
+   * @param ModuleInfo $moduleInfo
+   */
+
+  public function renderContent($renderApi, $unit, $moduleInfo)
+  {
+    $isNotRedirect = ($renderApi->getFormValue($unit, 'confirmationType') != 'redirect');
+    list($form, $honeyPotComponent) = $this->setupForm($unit);
+
+    $formSend = false;
+    try {
+      $formSend = $this->checkFormAndSendMail($renderApi, $unit, $honeyPotComponent);
+    } catch (\Exception $e) {
+      $errorText = new \Span();
+      $errorText->setContent("Unable to send email:<br />" . $e->getMessage());
+      $errorContainer = new \Container();
+      $errorContainer->add($errorText);
+      $errorContainer->getElementProperties()->addClass('vf__main_error');
+      $form->add($errorContainer);
     }
 
     if ($formSend) {
-      $confirmationText = new \Span();
-      $confirmationText->setContent(preg_replace('/\n/', '<br>', $renderApi->getFormValue($unit, 'confirmationText')));
-      $confirmationContainer = new \Container();
-      $confirmationContainer->add($confirmationText);
-      $confirmationContainer->getElementProperties()->addClass('confirmationText');
-      $form->add($confirmationContainer);
-      echo $form->renderElement();
+      if ($isNotRedirect) {
+        $confirmationText = new \Span();
+        $confirmationText->setContent(preg_replace('/\n/', '<br>', $renderApi->getFormValue($unit, 'confirmationText')));
+        $confirmationContainer = new \Container();
+        $confirmationContainer->add($confirmationText);
+        $confirmationContainer->getElementProperties()->addClass('confirmationText');
+        $form->add($confirmationContainer);
+        echo $form->renderElement();
+      }
     } else {
       echo $form->renderElementProgressive($renderApi, $unit);
     }

--- a/app/sets/rukzuk/rz_core/modules/rz_form/module/rz_form.php
+++ b/app/sets/rukzuk/rz_core/modules/rz_form/module/rz_form.php
@@ -119,7 +119,7 @@ class rz_form extends SimpleModule
     ) {
       $this->formSubmit->setFieldLabelsToFormValueSet($renderApi);
       try {
-        $this->sentEmail($renderApi, $unit, $postRequest);
+        $this->sendEmail($renderApi, $unit, $postRequest);
         return true;
       } catch (\Exception $e) {
         throw $e;
@@ -172,7 +172,7 @@ class rz_form extends SimpleModule
    * @param Unit      $unit
    * @param array     $postRequest <FormValueSetSet>
    */
-  private function sentEmail($renderApi, $unit, $postRequest)
+  private function sendEmail($renderApi, $unit, $postRequest)
   {
     $mailer = new Mailer($renderApi);
     $mailer->setFrom($renderApi->getFormValue($unit, 'senderMail'));


### PR DESCRIPTION
Adds support for an internal page redirect after successful form submit. The successful text display is still possible (can be chosen in the form of the module).
