### PR TITLE
rz_style_icon/rz_style_iconset: choose between before & after

### DIFF
--- a/app/sets/rukzuk/rz_core/modules/rz_style_icon/assets/notlive/css.js
+++ b/app/sets/rukzuk/rz_core/modules/rz_style_icon/assets/notlive/css.js
@@ -52,8 +52,8 @@ DynCSS.defineModule('rz_style_icon', function (api, v, ctx) {
             }
         }
 
-        return {
-            '&:after': css
-        };
+        var cssWrapper = {};
+        cssWrapper['&:' + v.cssPseudoElement] = css;
+        return cssWrapper;
     }
 });

--- a/app/sets/rukzuk/rz_core/modules/rz_style_icon/module/form.json
+++ b/app/sets/rukzuk/rz_core/modules/rz_style_icon/module/form.json
@@ -289,6 +289,134 @@
                                     "params": [
                                         {
                                             "name": "CMSvar",
+                                            "value": "cssPseudoElement",
+                                            "allowBlank": false,
+                                            "minLength": 3,
+                                            "maskRe": {},
+                                            "stripCharsRe": {},
+                                            "xtype": "textfield",
+                                            "emptyText": "__i18n_generatedFormPanel.varNameEmptyText",
+                                            "fieldLabel": "__i18n_generatedFormPanel.varNameLabel"
+                                        },
+                                        {
+                                            "name": "xtype",
+                                            "value": "CMStabbedfieldset",
+                                            "xtype": null
+                                        },
+                                        {
+                                            "name": "isResponsive",
+                                            "value": false,
+                                            "fieldLabel": "__i18n_formElements.isResponsive",
+                                            "xtype": "checkbox"
+                                        },
+                                        {
+                                            "name": "isMeta",
+                                            "value": false,
+                                            "fieldLabel": "__i18n_formElements.isGlobal",
+                                            "xtype": "checkbox"
+                                        },
+                                        {
+                                            "name": "fieldLabel",
+                                            "value": "",
+                                            "xtype": "textfield",
+                                            "allowBlank": true,
+                                            "emptyText": "__i18n_formElements.fieldLabelOptionalEmptyText",
+                                            "fieldLabel": "__i18n_formElements.fieldLabel"
+                                        },
+                                        {
+                                            "name": "value",
+                                            "value": "after",
+                                            "xtype": null
+                                        }
+                                    ],
+                                    "descr": {
+                                        "id": "TabbedFieldSet",
+                                        "text": "__i18n_formElements.elementTabbedFieldSet",
+                                        "iconCls": "tabbedfieldset",
+                                        "hasValue": true,
+                                        "allowChildNodes": true
+                                    },
+                                    "items": [
+                                        {
+                                            "params": [
+                                                {
+                                                    "name": "xtype",
+                                                    "value": "CMStabpage",
+                                                    "xtype": null
+                                                },
+                                                {
+                                                    "name": "tabValue",
+                                                    "xtype": "textfield",
+                                                    "allowBlank": false,
+                                                    "emptyText": "__i18n_formElements.groupValueEmptyText",
+                                                    "fieldLabel": "__i18n_formElements.groupValueFieldLabel",
+                                                    "value": "before"
+                                                },
+                                                {
+                                                    "name": "title",
+                                                    "value": "{\"de\":\"links vor Inhalt\",\"en\":\"before content\"}",
+                                                    "xtype": "textfield",
+                                                    "allowBlank": false,
+                                                    "emptyText": "__i18n_formElements.title",
+                                                    "fieldLabel": "__i18n_formElements.title"
+                                                },
+                                                {
+                                                    "name": "value",
+                                                    "xtype": null,
+                                                    "value": "before"
+                                                }
+                                            ],
+                                            "descr": {
+                                                "id": "TabPage",
+                                                "text": "__i18n_formElements.elementTabPage",
+                                                "iconCls": "tabpage",
+                                                "hasValue": false,
+                                                "allowChildNodes": true
+                                            }
+                                        },
+                                        {
+                                            "params": [
+                                                {
+                                                    "name": "xtype",
+                                                    "value": "CMStabpage",
+                                                    "xtype": null
+                                                },
+                                                {
+                                                    "name": "tabValue",
+                                                    "xtype": "textfield",
+                                                    "allowBlank": false,
+                                                    "emptyText": "__i18n_formElements.groupValueEmptyText",
+                                                    "fieldLabel": "__i18n_formElements.groupValueFieldLabel",
+                                                    "value": "after"
+                                                },
+                                                {
+                                                    "name": "title",
+                                                    "value": "{\"de\":\"rechts nach Inhalt\",\"en\":\"after content\"}",
+                                                    "xtype": "textfield",
+                                                    "allowBlank": false,
+                                                    "emptyText": "__i18n_formElements.title",
+                                                    "fieldLabel": "__i18n_formElements.title"
+                                                },
+                                                {
+                                                    "name": "value",
+                                                    "xtype": null,
+                                                    "value": "after"
+                                                }
+                                            ],
+                                            "descr": {
+                                                "id": "TabPage",
+                                                "text": "__i18n_formElements.elementTabPage",
+                                                "iconCls": "tabpage",
+                                                "hasValue": false,
+                                                "allowChildNodes": true
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "params": [
+                                        {
+                                            "name": "CMSvar",
                                             "value": "cssShiftX",
                                             "allowBlank": false,
                                             "minLength": 3,
@@ -1018,6 +1146,7 @@
             "type": "bp",
             "default": false
         },
+        "cssPseudoElement": "after",
         "cssShiftX": {
             "type": "bp",
             "default": "0px"

--- a/app/sets/rukzuk/rz_core/modules/rz_style_iconset/assets/notlive/css.js
+++ b/app/sets/rukzuk/rz_core/modules/rz_style_iconset/assets/notlive/css.js
@@ -21,7 +21,6 @@ DynCSS.defineModule('rz_style_iconset', function (api, v) {
 			fontSize: iconSize,
 			color: color,
 			transform: rotate
-			
         };
 
 		if (v.cssEnableTextShadow) {
@@ -60,8 +59,9 @@ DynCSS.defineModule('rz_style_iconset', function (api, v) {
                 css.zIndex = '-1';
             }
         }
-        return {
-            '&:after': css
-        };
+
+        var cssWrapper = {};
+        cssWrapper['&:' + v.cssPseudoElement] = css;
+        return cssWrapper;
     }
 });

--- a/app/sets/rukzuk/rz_core/modules/rz_style_iconset/module/form.json
+++ b/app/sets/rukzuk/rz_core/modules/rz_style_iconset/module/form.json
@@ -761,6 +761,134 @@
                                     "params": [
                                         {
                                             "name": "CMSvar",
+                                            "value": "cssPseudoElement",
+                                            "allowBlank": false,
+                                            "minLength": 3,
+                                            "maskRe": {},
+                                            "stripCharsRe": {},
+                                            "xtype": "textfield",
+                                            "emptyText": "__i18n_generatedFormPanel.varNameEmptyText",
+                                            "fieldLabel": "__i18n_generatedFormPanel.varNameLabel"
+                                        },
+                                        {
+                                            "name": "xtype",
+                                            "value": "CMStabbedfieldset",
+                                            "xtype": null
+                                        },
+                                        {
+                                            "name": "isResponsive",
+                                            "value": false,
+                                            "fieldLabel": "__i18n_formElements.isResponsive",
+                                            "xtype": "checkbox"
+                                        },
+                                        {
+                                            "name": "isMeta",
+                                            "value": false,
+                                            "fieldLabel": "__i18n_formElements.isGlobal",
+                                            "xtype": "checkbox"
+                                        },
+                                        {
+                                            "name": "fieldLabel",
+                                            "value": "",
+                                            "xtype": "textfield",
+                                            "allowBlank": true,
+                                            "emptyText": "__i18n_formElements.fieldLabelOptionalEmptyText",
+                                            "fieldLabel": "__i18n_formElements.fieldLabel"
+                                        },
+                                        {
+                                            "name": "value",
+                                            "value": "after",
+                                            "xtype": null
+                                        }
+                                    ],
+                                    "descr": {
+                                        "id": "TabbedFieldSet",
+                                        "text": "__i18n_formElements.elementTabbedFieldSet",
+                                        "iconCls": "tabbedfieldset",
+                                        "hasValue": true,
+                                        "allowChildNodes": true
+                                    },
+                                    "items": [
+                                        {
+                                            "params": [
+                                                {
+                                                    "name": "xtype",
+                                                    "value": "CMStabpage",
+                                                    "xtype": null
+                                                },
+                                                {
+                                                    "name": "tabValue",
+                                                    "xtype": "textfield",
+                                                    "allowBlank": false,
+                                                    "emptyText": "__i18n_formElements.groupValueEmptyText",
+                                                    "fieldLabel": "__i18n_formElements.groupValueFieldLabel",
+                                                    "value": "before"
+                                                },
+                                                {
+                                                    "name": "title",
+                                                    "value": "{\"de\":\"links vor Inhalt\",\"en\":\"before content\"}",
+                                                    "xtype": "textfield",
+                                                    "allowBlank": false,
+                                                    "emptyText": "__i18n_formElements.title",
+                                                    "fieldLabel": "__i18n_formElements.title"
+                                                },
+                                                {
+                                                    "name": "value",
+                                                    "xtype": null,
+                                                    "value": "before"
+                                                }
+                                            ],
+                                            "descr": {
+                                                "id": "TabPage",
+                                                "text": "__i18n_formElements.elementTabPage",
+                                                "iconCls": "tabpage",
+                                                "hasValue": false,
+                                                "allowChildNodes": true
+                                            }
+                                        },
+                                        {
+                                            "params": [
+                                                {
+                                                    "name": "xtype",
+                                                    "value": "CMStabpage",
+                                                    "xtype": null
+                                                },
+                                                {
+                                                    "name": "tabValue",
+                                                    "xtype": "textfield",
+                                                    "allowBlank": false,
+                                                    "emptyText": "__i18n_formElements.groupValueEmptyText",
+                                                    "fieldLabel": "__i18n_formElements.groupValueFieldLabel",
+                                                    "value": "after"
+                                                },
+                                                {
+                                                    "name": "title",
+                                                    "value": "{\"de\":\"rechts nach Inhalt\",\"en\":\"after content\"}",
+                                                    "xtype": "textfield",
+                                                    "allowBlank": false,
+                                                    "emptyText": "__i18n_formElements.title",
+                                                    "fieldLabel": "__i18n_formElements.title"
+                                                },
+                                                {
+                                                    "name": "value",
+                                                    "xtype": null,
+                                                    "value": "after"
+                                                }
+                                            ],
+                                            "descr": {
+                                                "id": "TabPage",
+                                                "text": "__i18n_formElements.elementTabPage",
+                                                "iconCls": "tabpage",
+                                                "hasValue": false,
+                                                "allowChildNodes": true
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "params": [
+                                        {
+                                            "name": "CMSvar",
                                             "value": "cssShiftX",
                                             "allowBlank": false,
                                             "minLength": 3,
@@ -5120,6 +5248,7 @@
             "type": "bp",
             "default": false
         },
+        "cssPseudoElement": "after",
         "cssShiftX": {
             "type": "bp",
             "default": "0px"


### PR DESCRIPTION
Hi @sebastianroller,
multiple times I had the need to place an icon before an element, not only after it. Sometimes it worked well just playing with the sliders, e.g. setting the x-position to -100%. But I also had cases where this didn't work, so I added an option to choose if the icon should be placed before or after an element (CSS :before or :after). :after is still the default, so it should be compatible.

What do you think, does this option makes sense? Till now, I see two imperfections:
- it only works with relative position. When choosing an absolute position (which is the default when activating the positioning) it doesn't make a visual difference to the layout. It doesn't break, but it's confusing. Since we currently can't change the default value to relative, I'm actually thinking of moving the option into the tab "type">"relative", so it's only visible if relative position is selected. But there it's very hidden.
- for simplicity I didn't enable responsive values for before/after, but this support could be added.