### PR TITLE
feat: add htaccess to creator and website settings

### DIFF
--- a/app/server/library/Cms/Creator/Adapter/DynamicCreator/CreatorStorage.php
+++ b/app/server/library/Cms/Creator/Adapter/DynamicCreator/CreatorStorage.php
@@ -78,6 +78,7 @@ class CreatorStorage extends AbstractCreatorStorage
     $this->createUsedMediaItems();
     $this->createUsedAlbumInfo();
     $this->createWebsiteSettingsInfo();
+    $this->createHtaccessFromWebsiteSettings();
     $this->createColorInfo();
     $this->createResolutionInfo();
     $this->createNavigation();
@@ -603,6 +604,28 @@ class CreatorStorage extends AbstractCreatorStorage
     );
     $comments = array("website settings info array", "site: " . $this->getWebsiteId());
     $this->exportDataToFile($websiteSettingsInfoFilePath, $this->websiteSettings, $comments);
+  }
+
+  protected function createHtaccessFromWebsiteSettings()
+  {
+    if (array_key_exists('htaccess', $this->websiteSettings)) {
+      if(isset($this->websiteSettings['htaccess']['htaccessContent']) 
+         && !empty($this->websiteSettings['htaccess']['htaccessContent'])) {
+        $content = $this->websiteSettings['htaccess']['htaccessContent'];
+      } else {
+        return; // end here
+      }
+    }
+
+    $htaccessFilePath = FS::joinPath(
+        $this->getWebsiteDirectory(),
+        '.htaccess'
+    );
+    FS::writeContentToFile(
+        $htaccessFilePath,
+        $content,
+        "Error at creating file '%s' (%s): %s"
+    );
   }
 
   protected function createColorInfo()

--- a/app/server/library/Cms/Creator/Adapter/DynamicCreator/CreatorStorage.php
+++ b/app/server/library/Cms/Creator/Adapter/DynamicCreator/CreatorStorage.php
@@ -608,6 +608,7 @@ class CreatorStorage extends AbstractCreatorStorage
 
   protected function createHtaccessFromWebsiteSettings()
   {
+    $content = "";
     if (array_key_exists('htaccess', $this->websiteSettings)) {
       if(isset($this->websiteSettings['htaccess']['htaccessContent']) 
          && !empty($this->websiteSettings['htaccess']['htaccessContent'])) {

--- a/app/sets/rukzuk/rz_core/pkg.json
+++ b/app/sets/rukzuk/rz_core/pkg.json
@@ -7,7 +7,7 @@
     "de": "",
     "en": ""
   },
-  "websiteSettings": ["password_protection", "custom_page_properties"],
+  "websiteSettings": ["password_protection", "custom_page_properties", "htaccess"],
   "pageTypes": [],
   "templateSnippets": [
     "TPLS-global00-0000-0000-0000-30col0text00-TPLS",

--- a/app/sets/rukzuk/rz_core/websiteSettings/htaccess/websiteSettings.json
+++ b/app/sets/rukzuk/rz_core/websiteSettings/htaccess/websiteSettings.json
@@ -1,0 +1,26 @@
+{
+    "name": {
+        "de": ".htaccess (Apache)",
+        "en": ".htaccess (Apache)"
+    },
+    "description": {
+        "de": "Servereinstellungen anpassen. Funktioniert nur wenn Website auf Apache läuft. Je nach Server sind gar keine oder weniger funktionen verfügbar.",
+        "en": "Change Server settings. Only works with Apache webservers and if enabled."
+    },
+    "version": "dev",
+    "formValues": {
+        "htaccessContent": ""
+    },
+    "form": [
+        {
+            "type": "Comment",
+            "text": "{\"de\": \"Hier können .htaccess Regeln eingegeben werden. Hilfe: http://www.htaccess-guide.com\", \"en\": \"Enter .htaccess directives. Help: http://www.htaccess-guide.com\"}"
+        },
+        {
+            "type": "TextArea",
+            "CMSvar": "htaccessContent",
+            "height": 400,
+            "fieldLabel": "{\"de\": \".htaccess Inhalt\", \"en\": \".htaccess Content\"}"
+        }
+    ]
+}


### PR DESCRIPTION
Needs changes in cms.apache (https://github.com/rukzuk/rukzuk/blob/master/docker/cms.apache#L12) to work with the docker hosting. Also: This might not be suitable for the current hosting platform. 

Currently there is no method for checking if the website-settings should be visible, this could be added as requires: supportedPublishTypes=internal or something similar.

Still putting this here for discussion.