### PR TITLE
implement a sitemap.xml feature

### DIFF
--- a/app/default/pageType/pageType.json
+++ b/app/default/pageType/pageType.json
@@ -158,6 +158,11 @@
             "type": "OnOffToggle",
             "CMSvar": "notInPageList",
             "fieldLabel": "{\"de\": \"Diese Seite nicht in Seitenlisten anzeigen\", \"en\": \"Hide this page on page lists\"}"
+        },
+        {
+            "type": "OnOffToggle",
+            "CMSvar": "notInSitemapXml",
+            "fieldLabel": "{\"de\": \"Diese Seite nicht in sitemap.xml aufnehmen\", \"en\": \"Exclude this page in sitemap.xml\"}"
         }
     ],
     "formValues": {
@@ -168,6 +173,8 @@
         "_description": "",
         "_mediaId": null,
         "enableRedirect": false,
-        "redirectType": "firstChild"
+        "redirectType": "firstChild",
+        "notInPageList": false,
+        "notInSitemapXml": false
     }
 }

--- a/app/server/library/Cms/Creator/Adapter/DynamicCreator/PageCreator.php
+++ b/app/server/library/Cms/Creator/Adapter/DynamicCreator/PageCreator.php
@@ -73,8 +73,13 @@ class PageCreator
   protected function addPageToStorage(PreparePageResult $preparePageResult)
   {
     $storage = $this->getCreatorStorage();
+    // attributes might be needed in the creator
+    $storage->addPageAttributes($preparePageResult->getPageId(), $preparePageResult->getPageAttributes());
     if (!$preparePageResult->getFilesCreated()) {
       $this->createPageFiles($storage, $preparePageResult);
+    } else {
+        // clean up page attributes after we saved them
+        $preparePageResult->resetPageAttributes();
     }
     if ($preparePageResult->getLegacySupport()) {
       $storage->addLegacyPage($preparePageResult->getPageId());

--- a/app/server/library/Cms/Creator/Adapter/DynamicCreator/PreparePage.php
+++ b/app/server/library/Cms/Creator/Adapter/DynamicCreator/PreparePage.php
@@ -515,7 +515,7 @@ class PreparePage
     // remove data from result
     $this->result->resetPageMeta();
     $this->result->resetPageGlobal();
-    $this->result->resetPageAttributes();
+    //we need them later $this->result->resetPageAttributes();
     $this->result->resetPageContent();
     $this->result->resetCssCacheValue();
     $this->result->resetHtmlCacheValue();

--- a/app/server/library/composer.json
+++ b/app/server/library/composer.json
@@ -7,7 +7,8 @@
         "doctrine/orm": "2.6.*",
         "doctrine/migrations": "1.*",
         "leafo/scssphp": "~0.8.4",
-        "segmentio/analytics-php": "1.2.0"
+        "segmentio/analytics-php": "1.2.0",
+        "ext-dom": "*"
     },
     "repositories": [
         {

--- a/app/sets/rukzuk/rz_core/pkg.json
+++ b/app/sets/rukzuk/rz_core/pkg.json
@@ -7,7 +7,7 @@
     "de": "",
     "en": ""
   },
-  "websiteSettings": ["password_protection", "custom_page_properties", "htaccess", "privacy"],
+  "websiteSettings": ["password_protection", "custom_page_properties", "htaccess", "privacy", "sitemap_xml"],
   "pageTypes": [],
   "templateSnippets": [
     "TPLS-global00-0000-0000-0000-30col0text00-TPLS",

--- a/app/sets/rukzuk/rz_core/websiteSettings/sitemap_xml/websiteSettings.json
+++ b/app/sets/rukzuk/rz_core/websiteSettings/sitemap_xml/websiteSettings.json
@@ -1,0 +1,36 @@
+{
+    "name": {
+        "de": "Sitemap (XML)",
+        "en": "Sitemap (XML)"
+    },
+    "description": {
+        "de": "Erlaubt das erstellen einer sitemap.xml für Suchmaschinen.",
+        "en": "Create sitemap xml files for search engines."
+    },
+    "version": "dev",
+    "formValues": {
+        "enableSitemapXml": false,
+        "robotsTxt": "",
+        "domain": ""
+    },
+    "form": [
+        {
+            "type": "OnOffFieldSet",
+            "CMSvar": "enableSitemapXml",
+            "fieldLabel": "{\"de\": \"Eine sitemap.xml generieren.\", \"en\": \"Generate sitemap.xml.\"}",
+            "_items": [
+                {
+                    "type": "TextField",
+                    "CMSvar": "domain",
+                    "fieldLabel": "{\"de\": \"Domain und Pfad zur Seite z. b. https://meine.seite\", \"en\": \"Domain and path to page e.g. https://my.page\"}"
+                },
+                {
+                    "type": "TextArea",
+                    "CMSvar": "robotsTxt",
+                    "height": 100,
+                    "fieldLabel": "{\"de\": \"Weitere robots.txt angaben\", \"en\": \"More robots.txt definitions\"}"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This brings a sitemap.xml file and a robots.txt file (with possible user content) to rukzuk. The only caveat is that the domain needs to be specified again in the `Project Settings -> Sitemap XML` which is a limitation of the current builder and publisher approach. We might get that data somehow but it's tricky and therefore I went with the simple workaround.